### PR TITLE
RHTAP prep for release-2.11

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -1,0 +1,17 @@
+# Copyright Contributors to the Open Cluster Management project
+# Licensed under the Apache License 2.0
+
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.20 AS builder
+
+WORKDIR /workspace
+COPY . .
+
+RUN GOOS=linux GOFLAGS="" GOARCH=amd64 CGO_ENABLED=1 go build -o operator cmd/operator/main.go
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+COPY --from=builder /workspace/operator /bin/operator
+
+USER nobody
+
+ENTRYPOINT ["/bin/operator"]


### PR DESCRIPTION
Required by [ACM-10834](https://issues.redhat.com/browse/ACM-10834)

Add docker file for RHTAP builds (with a new base image) to release-2.11 builds

cc: @Kyl-Bempah 