### PR TITLE
Konflux: don't set arch in build commands (release-2.12)

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -7,7 +7,7 @@ WORKDIR /workspace
 COPY . .
 
 RUN go mod vendor
-RUN GOOS=linux GOFLAGS="" GOARCH=amd64 CGO_ENABLED=1 go build -o operator cmd/operator/main.go
+RUN GOFLAGS="" CGO_ENABLED=1 go build -o operator ./cmd/operator/
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 

--- a/cmd/prometheus-config-reloader/Containerfile.operator
+++ b/cmd/prometheus-config-reloader/Containerfile.operator
@@ -7,7 +7,7 @@ WORKDIR /workspace
 COPY . .
 
 RUN go mod vendor
-RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -o prometheus-config-reloader cmd/prometheus-config-reloader/main.go
+RUN CGO_ENABLED=1 go build -o prometheus-config-reloader ./cmd/prometheus-config-reloader/
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 


### PR DESCRIPTION
Fixes multiarch builds.