### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for prometheus-config-reloader-acm-214

### DIFF
--- a/cmd/prometheus-config-reloader/Containerfile.operator
+++ b/cmd/prometheus-config-reloader/Containerfile.operator
@@ -18,7 +18,8 @@ USER nobody
 ENTRYPOINT ["/bin/prometheus-config-reloader"]
 
 LABEL com.redhat.component="prometheus-config-reloader" \
-  name="prometheus-config-reloader" \
+  name="rhacm2/acm-prometheus-config-reloader-rhel9" \
+  cpe="cpe:/a:redhat:acm:2.14::el9" \
   summary="prometheus-config-reloader" \
   io.openshift.expose-services="" \
   io.openshift.tags="data,images" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
