### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for prometheus-operator-acm-214

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -18,7 +18,8 @@ USER nobody
 ENTRYPOINT ["/bin/operator"]
 
 LABEL com.redhat.component="prometheus-operator" \
-  name="prometheus-operator" \
+  name="rhacm2/acm-prometheus-rhel9" \
+  cpe="cpe:/a:redhat:acm:2.14::el9" \
   summary="prometheus-operator" \
   io.openshift.expose-services="" \
   io.openshift.tags="data,images" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
