### PR TITLE
fix name label (do not include -operator)

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -18,7 +18,7 @@ USER nobody
 ENTRYPOINT ["/bin/operator"]
 
 LABEL com.redhat.component="prometheus-operator" \
-  name="rhacm2/acm-prometheus-operator-rhel9" \
+  name="rhacm2/acm-prometheus-rhel9" \
   cpe="cpe:/a:redhat:acm:2.17::el9" \
   summary="prometheus-operator" \
   io.openshift.expose-services="" \


### PR DESCRIPTION
For historic reasons, the prometheus operator image name label appears to be `acm-prometheus-rhel9`. Corrected in this PR.