### PR TITLE
Set UID instead of username

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -13,7 +13,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 COPY --from=builder /workspace/operator /bin/operator
 
-USER nobody
+USER 1001
 
 ENTRYPOINT ["/bin/operator"]
 

--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -11,6 +11,6 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 COPY --from=builder /workspace/operator /bin/operator
 
-USER nobody
+USER 1001
 
 ENTRYPOINT ["/bin/operator"]

--- a/cmd/prometheus-config-reloader/Containerfile.operator
+++ b/cmd/prometheus-config-reloader/Containerfile.operator
@@ -13,7 +13,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 COPY --from=builder /workspace/prometheus-config-reloader /bin/prometheus-config-reloader
 
-USER nobody
+USER 1001
 
 ENTRYPOINT ["/bin/prometheus-config-reloader"]
 

--- a/cmd/prometheus-config-reloader/Dockerfile.prow
+++ b/cmd/prometheus-config-reloader/Dockerfile.prow
@@ -12,6 +12,6 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 COPY --from=builder /workspace/prometheus-config-reloader /bin/prometheus-config-reloader
 
-USER nobody
+USER 1001
 
 ENTRYPOINT ["/bin/prometheus-config-reloader"]


### PR DESCRIPTION
Fixes the following which occurs in MCOA on non-ocp clusters.
```
CreateContainerConfigError: “container has runAsNonRoot and image has non-numeric user (nobody),  cannot verify user is non-root”
```