### PR TITLE
feat: add .cve-fix/examples.md guidance for CVE fixer workflow

### DIFF
--- a/.cve-fix/examples.md
+++ b/.cve-fix/examples.md
@@ -1,0 +1,30 @@
+<!-- last-analyzed: 2026-04-16 | cve-merged: 4 -->
+
+## Titles
+- `fix(cve): CVE-YYYY-XXXXX - <package>` (4/22 merged PRs)
+  - e.g. `fix(cve): CVE-2026-33186 - google.golang.org/grpc [release-2.17]`
+  - e.g. `fix(cve): CVE-2026-33186 - google.golang.org/grpc [release-2.16]`
+
+## Branches
+- `fix/cve-<id>-<pkg>-<branch>-attempt-N` (4/22 merged PRs)
+  - e.g. `fix/cve-2026-33186-grpc-release-2.17-attempt-1`
+  - e.g. `fix/cve-2026-33186-grpc-release-2.16-attempt-1`
+
+## Files
+- `go.mod` + `go.sum` always change together for Go dependency updates
+- `Dockerfile` / `Containerfile.operator` may also be updated (Go version bumps)
+
+## Co-upgrades
+- When bumping a Go dependency, always run `go mod tidy` to update `go.sum`
+- Go version bumps (`go.mod` directive) often require updating `Dockerfile` / `Containerfile.operator`
+
+## PR Description
+- Include CVE ID, severity, and affected package in description
+- Reference the target branch (e.g. `release-2.16`) when targeting non-default branches
+- Include test results section
+- For multi-branch fixes, create separate PRs per branch (not a single PR)
+
+## Don'ts
+- ❌ Do not combine multiple CVE fixes in a single PR
+- ❌ Do not target the wrong release branch (verify `--base` matches intended branch)
+- ❌ Do not skip `go mod tidy` — incomplete `go.sum` updates will fail CI


### PR DESCRIPTION
## CVE Fix Guidance

Adds `.cve-fix/examples.md` with patterns extracted from merged CVE/dependency PRs in this repo and across the stolostron org.

This file guides the automated CVE fixer workflow to create PRs matching this repo's conventions (title format, branch naming, files changed, etc.).

### What's Included
- Title conventions for CVE fix PRs
- Branch naming patterns
- Files that typically change together
- Co-upgrade guidance (e.g. go.mod + go.sum)
- PR description expectations
- Anti-patterns to avoid

🤖 Generated by /onboard