### PR TITLE
Add Dockerfile.art for ART/Brew build migration

### DIFF
--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -1,0 +1,29 @@
+# Copyright Contributors to the Open Cluster Management project
+# Licensed under the Apache License 2.0
+
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.25.8 AS builder
+
+WORKDIR /workspace
+COPY . .
+
+RUN go mod vendor
+RUN GOFLAGS="" CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build -o operator ./cmd/operator/
+
+FROM registry-proxy.engineering.redhat.com/ubi9/ubi-minimal:latest
+
+COPY --from=builder /workspace/operator /bin/operator
+
+USER 1001
+
+ENTRYPOINT ["/bin/operator"]
+
+LABEL com.redhat.component="prometheus-operator" \
+  name="rhacm2/acm-prometheus-rhel9" \
+  cpe="cpe:/a:redhat:acm:2.16::el9" \
+  summary="prometheus-operator" \
+  io.openshift.expose-services="" \
+  io.openshift.tags="data,images" \
+  io.k8s.display-name="prometheus-operator" \
+  maintainer="" \
+  description="prometheus-operator" \
+  io.k8s.description="prometheus-operator"

--- a/cmd/prometheus-config-reloader/Dockerfile.art
+++ b/cmd/prometheus-config-reloader/Dockerfile.art
@@ -1,0 +1,29 @@
+# Copyright Contributors to the Open Cluster Management project
+# Licensed under the Apache License 2.0
+
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.25.8 AS builder
+
+WORKDIR /workspace
+COPY . .
+
+RUN go mod vendor
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build -o prometheus-config-reloader ./cmd/prometheus-config-reloader/
+
+FROM registry-proxy.engineering.redhat.com/ubi9/ubi-minimal:latest
+
+COPY --from=builder /workspace/prometheus-config-reloader /bin/prometheus-config-reloader
+
+USER 1001
+
+ENTRYPOINT ["/bin/prometheus-config-reloader"]
+
+LABEL com.redhat.component="prometheus-config-reloader" \
+  name="rhacm2/acm-prometheus-config-reloader-rhel9" \
+  cpe="cpe:/a:redhat:acm:2.16::el9" \
+  summary="prometheus-config-reloader" \
+  io.openshift.expose-services="" \
+  io.openshift.tags="data,images" \
+  io.k8s.display-name="prometheus-config-reloader" \
+  maintainer="" \
+  description="prometheus-config-reloader" \
+  io.k8s.description="prometheus-config-reloader"


### PR DESCRIPTION
HYPBLD-847: ACM 2.16: Create Dockerfile.art + ocp-build-data config
https://redhat.atlassian.net/browse/HYPBLD-847

Create the build configuration required for ART to build ACM 2.16 components.

Dockerfile.art files (50 repos):                                                                     
- Create Dockerfile.art in each ACM repo on release-2.16 branch                                      
- Use existing Dockerfile.rhtap as starting point                                                    
- Change registry to registry-proxy.engineering.redhat.com
- Add FIPS flags (GOEXPERIMENT=strictfipsruntime, CGO_ENABLED=1)                                     
Note: multiclusterhub-operator uses brew.registry — needs manual FROM line conversion              

Signed-off-by: Brian Smith (briansmi@redhat.com)