### PR TITLE
[TEST] Dummy no-op change to establish E2E baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,3 +196,5 @@ common issues and frequently asked questions (FAQ).
 ## Acknowledgements
 
 prometheus-operator organization logo was created and contributed by [Bianca Cheng Costanzo](https://github.com/bia).
+
+<!-- dummy change for CI isolation test -->


### PR DESCRIPTION
Control test: no functional changes at all (just a comment in README.md) on top of unmodified release-2.17, to confirm the Prometheus Agent DaemonSet E2E tests pass on a clean baseline in the current CI environment. Compares against #235 (CVE fix only) and #232 (CVE fix + other stacked commits).

Not for merging - will close after checking E2E results.