### PR TITLE
[TEST] Dummy no-op change to establish E2E baseline (v2)

### DIFF
--- a/pkg/operator/rules.go
+++ b/pkg/operator/rules.go
@@ -14,6 +14,8 @@
 
 package operator
 
+// dummy comment for CI isolation test - no functional change
+
 import (
 	"context"
 	"errors"


### PR DESCRIPTION
Control test: no functional changes (trivial comment in pkg/operator/rules.go) on top of unmodified release-2.17, to confirm the Prometheus Agent DaemonSet E2E tests pass on a clean baseline in the current CI environment. Compares against #235 (CVE fix only, failed) and #232 (CVE fix + other stacked commits, failed).

Replaces #236 which was accidentally closed.

Not for merging - will close after checking E2E results.