### PR TITLE
Backport CI Testing To Release-2.16

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,4 +1,4 @@
-name: e2e
+name: e2e test
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
This is a backport of #229   , which adds e2e testing support for kube-state-metrics through Github Actions.