### PR TITLE
Backport CI Changes to Release 2.13

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,4 +1,4 @@
-name: e2e
+name: e2e test
 on:
   pull_request:
     paths-ignore:

--- a/test/e2e/scrapeconfig_test.go
+++ b/test/e2e/scrapeconfig_test.go
@@ -450,6 +450,8 @@ func testScrapeConfigKubernetesNodeRole(t *testing.T) {
 
 // testScrapeConfigDNSSDConfig tests whether DNS SD based monitoring works as expected.
 func testScrapeConfigDNSSDConfig(t *testing.T) {
+	t.Skip("DNS service discovery tests are disabled until we find a replacement for node.demo.do.prometheus.io")
+
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
 	ns := framework.CreateNamespace(context.Background(), t, testCtx)


### PR DESCRIPTION
This is a backport of https://github.com/stolostron/prometheus-operator/pull/229 , which adds e2e testing support for prometheus-operator through Github Actions.